### PR TITLE
Force envkey.sh script to run before any other buildpack scripts

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,18 +53,18 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   fi
 
   mkdir -p $BUILD_DIR/.profile.d
-  cat > $BUILD_DIR/.profile.d/envkey.sh << EOF
+  cat > $BUILD_DIR/.profile.d/00-envkey.sh << EOF
 export PATH=\$PATH:\$HOME/vendor/envkey/bin
 EOF
 
   if [ -f $ENV_DIR/ENVKEY_BUILD_PHASE_EXPORT ]; then
-    cat >> $BUILD_DIR/.profile.d/envkey.sh << EOF
+    cat >> $BUILD_DIR/.profile.d/00-envkey.sh << EOF
 export -p > ./envkey-runtime-env.sh
 $(cat $BP_DIR/export)
 . ./envkey-runtime-env.sh
 rm envkey-runtime-env.sh
 EOF
-    echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
+    echo "EnvKey variables exported to running application via .profile.d/00-envkey.sh" | indent
   fi
   
   echo "envkey-source executable is available for use" | indent


### PR DESCRIPTION
Setting environment variables is critical for other buildpacks (like the Datadog buildpack). 

But scripts in the `profile.d` folder are run in alphabetical order, therefore, any script with a letter between a-e would run before the `envkey.sh` is run, and, therefore, wouldn't have access to the env variables.

This PR changes the name of the `envkey.sh` script to `00-envkey.sh` to ensure it always runs before any other buildpack `profile.d` script.